### PR TITLE
Add database config to the identity-service so devices and users can be persisted

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       FIREBASE_PUSH_NOTIFICATIONS_ENABLED: false
       PGSSLMODE: disable
       PORT: 9702
-      SQL_DATABASE: mockbank
+      SQL_DATABASE: idpartner
       SQL_USER: postgres
       SQL_PASSWORD: welcome1
       SQL_HOST: docker.for.mac.localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,15 @@ services:
       APN_KEY_ID: CHANGE_ME-APN_KEY_ID
       APN_TEAM_ID: CHANGE_ME-APN_TEAM_ID
       BANK_IDENTITY_SERVICE_URL: http://docker.for.mac.localhost:9702
+      BASE64_FIREBASE_PRIVATE_KEY: e30K
+      FIREBASE_PUSH_NOTIFICATIONS_ENABLED: false
+      PGSSLMODE: disable
       PORT: 9702
+      SQL_DATABASE: mockbank
+      SQL_USER: postgres
+      SQL_PASSWORD: welcome1
+      SQL_HOST: docker.for.mac.localhost
+      SQL_PORT: 5432
 
       ### Error Reporting Config
       SENTRY_DSN: https://xxx@yyy.ingest.sentry.io/000

--- a/scripts/docker-entrypoint-initdb.d/create_database.sql
+++ b/scripts/docker-entrypoint-initdb.d/create_database.sql
@@ -1,1 +1,2 @@
 CREATE DATABASE idpartner;
+CREATE DATABASE mockbank;

--- a/scripts/docker-entrypoint-initdb.d/create_database.sql
+++ b/scripts/docker-entrypoint-initdb.d/create_database.sql
@@ -1,2 +1,1 @@
 CREATE DATABASE idpartner;
-CREATE DATABASE mockbank;

--- a/scripts/setup_local.sh
+++ b/scripts/setup_local.sh
@@ -45,13 +45,8 @@ sleep 30
 # Run migrations
 docker run -e SQL_USER=postgres -e SQL_PASSWORD=welcome1 -e SQL_DATABASE=idpartner -e SQL_HOST=docker.for.mac.localhost ${MIGRATIONS_IMAGE}
 
-echo "Preparing to run mockbank migrations and seeds please wait..."
-sleep 30
-
-# Run migrations
-docker run -e SQL_USER=postgres -e SQL_PASSWORD=welcome1 -e SQL_DATABASE=mockbank -e SQL_HOST=docker.for.mac.localhost ${MIGRATIONS_IMAGE}
 # Run seeds
-docker run -e SQL_USER=postgres -e SQL_PASSWORD=welcome1 -e SQL_DATABASE=mockbank -e SQL_HOST=docker.for.mac.localhost ${MIGRATIONS_IMAGE} yarn seed
+docker run -e SQL_USER=postgres -e SQL_PASSWORD=welcome1 -e SQL_DATABASE=idpartner -e SQL_HOST=docker.for.mac.localhost ${MIGRATIONS_IMAGE} yarn seed
 
 # Stop services
 docker compose down

--- a/scripts/setup_local.sh
+++ b/scripts/setup_local.sh
@@ -17,7 +17,7 @@ usage () {
 }
 
 ############################################################################
-# 
+#
 #           MAIN
 #
 ############################################################################
@@ -44,6 +44,7 @@ sleep 30
 
 # Run migrations
 docker run -e SQL_USER=postgres -e SQL_PASSWORD=welcome1 -e SQL_DATABASE=idpartner -e SQL_HOST=docker.for.mac.localhost ${MIGRATIONS_IMAGE}
+docker run -e SQL_USER=postgres -e SQL_PASSWORD=welcome1 -e SQL_DATABASE=mockbank -e SQL_HOST=docker.for.mac.localhost ${MIGRATIONS_IMAGE}
 
 # Stop services
 docker compose down

--- a/scripts/setup_local.sh
+++ b/scripts/setup_local.sh
@@ -39,7 +39,7 @@ export PG_DATA_OVERRIDE
 docker compose up --detach --remove-orphans
 
 # Give the services 20s to come up
-echo "Preparing to run idpartner migrations please wait..."
+echo "Preparing to run migrations and seeds please wait..."
 sleep 30
 
 # Run migrations

--- a/scripts/setup_local.sh
+++ b/scripts/setup_local.sh
@@ -39,12 +39,19 @@ export PG_DATA_OVERRIDE
 docker compose up --detach --remove-orphans
 
 # Give the services 20s to come up
-echo "Preparing to run migrations please wait..."
+echo "Preparing to run idpartner migrations please wait..."
 sleep 30
 
 # Run migrations
 docker run -e SQL_USER=postgres -e SQL_PASSWORD=welcome1 -e SQL_DATABASE=idpartner -e SQL_HOST=docker.for.mac.localhost ${MIGRATIONS_IMAGE}
+
+echo "Preparing to run mockbank migrations and seeds please wait..."
+sleep 30
+
+# Run migrations
 docker run -e SQL_USER=postgres -e SQL_PASSWORD=welcome1 -e SQL_DATABASE=mockbank -e SQL_HOST=docker.for.mac.localhost ${MIGRATIONS_IMAGE}
+# Run seeds
+docker run -e SQL_USER=postgres -e SQL_PASSWORD=welcome1 -e SQL_DATABASE=mockbank -e SQL_HOST=docker.for.mac.localhost ${MIGRATIONS_IMAGE} yarn seed
 
 # Stop services
 docker compose down


### PR DESCRIPTION
A couple of things addressed in this PR:
- Add the ability to run migrations and seeds in the mock bank DB
- fix identity service with missing env vars

Depends on: https://github.com/idpartner-app/identity-provider-services/pull/30